### PR TITLE
Fixed self.process assignment

### DIFF
--- a/pysdtoken/pysdtoken.py
+++ b/pysdtoken/pysdtoken.py
@@ -188,6 +188,7 @@ class SDProcess:
         if dll_name:  # Passed in from init args
             self.dll_name = dll_name
             logger.debug(f'DLL name set to {self.dll_name} from arguments')
+            self.process = windll.LoadLibrary(self.dll_name)
 
         else:
             logger.debug("No dll name passed in during initialization. Determining correct default from platform/arch")


### PR DESCRIPTION
Fixed issue when specifying directory of dll. self.process was not being defined.

#11 